### PR TITLE
Implement login & remix endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ npm run build
 npm run start
 ```
 
+## API Endpoints
+
+Two helper endpoints are available once the server is running:
+
+* `GET /api/login` – Returns `{redirectUrl: "https://huggingface.co/login"}`. The frontend opens this URL in a new tab so you can sign in with your Hugging Face account.
+* `GET /api/remix/:path` – Loads a public Space at `:path` (for example `username/space-name`) and returns its HTML and ownership flag used by the editor.
+
 ### keywords
 deepsite local hosting, deepsite run locally, deepsite self-hosted, how to run deepsite locally, install deepsite on your machine, deepsite local server setup, deepsite offline mode, deepsite localhost tutorial, deploy deepsite on your own server, deepsite self-install guide, how to host deepsite on localhost step-by-step, can deepsite run offline on my computer, deepsite docker installation guide, full guide to running deepsite locally without internet, deepsite self-host vs cloud hosting comparison, deepsite performance tips when running locally, requirements to run deepsite on local environment, best practices for self-hosting deepsite platform, how to speed up deepsite in a local environment, common errors when running deepsite locally and how to fix, deepsite vs other ai site builders local run comparison, top reasons to run deepsite on your own server, is deepsite open-source and local-friendly
 

--- a/server.js
+++ b/server.js
@@ -167,6 +167,33 @@ app.post("/api/ask-ai", async (req, res) => {
   }
 });
 
+app.get("/api/login", (_req, res) => {
+  res.json({
+    redirectUrl: "https://huggingface.co/login",
+  });
+});
+
+app.get("/api/remix/:path(*)", async (req, res) => {
+  const { path: spacePath } = req.params;
+  if (!spacePath) {
+    return res.status(400).json({ message: "Space path is required" });
+  }
+  try {
+    const response = await fetch(
+      `https://huggingface.co/spaces/${spacePath}/raw/main/index.html`
+    );
+    if (!response.ok) {
+      return res
+        .status(response.status)
+        .json({ message: "Failed to fetch Space HTML" });
+    }
+    const html = await response.text();
+    res.json({ html, isOwner: false, path: spacePath });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
 app.get("*", (_req, res) => {
   res.sendFile(path.join(__dirname, "dist", "index.html"));
 });


### PR DESCRIPTION
## Summary
- add `/api/login` and `/api/remix/:path` routes
- document new API endpoints

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684263a3e81c83329925fbb8a05c2a95