### PR TITLE
Remove unused ESLint comments and improve types

### DIFF
--- a/src/components/ask-ai/ask-ai.tsx
+++ b/src/components/ask-ai/ask-ai.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useState } from "react";
 import { RiSparkling2Fill } from "react-icons/ri";
 import { GrSend } from "react-icons/gr";
@@ -12,6 +11,7 @@ import { defaultHTML } from "./../../../utils/consts";
 import SuccessSound from "./../../assets/success.mp3";
 import Settings from "../settings/settings";
 import ProModal from "../pro-modal/pro-modal";
+import { LocalSettings } from "../../../utils/types";
 
 function AskAI({
   html,
@@ -38,9 +38,9 @@ function AskAI({
   const [openProvider, setOpenProvider] = useState(false);
   const [providerError, setProviderError] = useState("");
   const [openProModal, setOpenProModal] = useState(false);
-  const [localSettings, setLocalSettings] = useState(() => {
+  const [localSettings, setLocalSettings] = useState<LocalSettings>(() => {
     const saved = localStorage.getItem('localSettings');
-    return saved ? JSON.parse(saved) : {
+    return saved ? (JSON.parse(saved) as LocalSettings) : {
       apiKey: "",
       apiUrl: "http://localhost:11434/v1",
       model: "gemma3:1b",
@@ -53,7 +53,7 @@ function AskAI({
   const loadLocalSettings = () => {
     const saved = localStorage.getItem('localSettings');
     if (saved) {
-      const parsed = JSON.parse(saved);
+      const parsed = JSON.parse(saved) as LocalSettings;
       setLocalSettings(parsed);
     } else {
       setLocalSettings({
@@ -177,11 +177,11 @@ function AskAI({
         read();
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
       setisAiWorking(false);
-      toast.error(error.message);
-      if (error.openLogin) {
+      const err = error as { message?: string; openLogin?: boolean };
+      toast.error(err.message ?? "An error occurred");
+      if (err.openLogin) {
         setOpen(true);
       }
     }

--- a/src/components/deploy-button/deploy-button.tsx
+++ b/src/components/deploy-button/deploy-button.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { toast } from "react-toastify";
 
 function DeployButton({

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import classNames from "classnames";
-import { useEffect } from "react";
+import { useEffect, useCallback } from "react";
 import { PiGearSixFill } from "react-icons/pi";
 // @ts-expect-error not needed
 import { PROVIDERS } from "./../../../utils/providers";
+import { LocalSettings } from "../../../utils/types";
 
 function Settings({
   open,
@@ -19,18 +19,18 @@ function Settings({
   error?: string;
   onClose: React.Dispatch<React.SetStateAction<boolean>>;
   onChange: (provider: string) => void;
-  localSettings: any;
-  setLocalSettings: React.Dispatch<React.SetStateAction<any>>;
+  localSettings: LocalSettings;
+  setLocalSettings: React.Dispatch<React.SetStateAction<LocalSettings>>;
 }) {
 
   // persist the local settings to local storage
-  const persistLocalSettings = () => {
+  const persistLocalSettings = useCallback(() => {
     localStorage.setItem('localSettings', JSON.stringify(localSettings));
-  };
+  }, [localSettings]);
 
   useEffect(() => {
     persistLocalSettings();
-  }, [localSettings]);
+  }, [persistLocalSettings]);
 
   return (
     <div className="">

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -4,3 +4,12 @@ export interface Auth {
   name: string;
   isLocalUse?: boolean;
 }
+
+export interface LocalSettings {
+  apiKey: string;
+  apiUrl: string;
+  model: string;
+  openRouterApiKey: string;
+  openRouterApiUrl: string;
+  openRouterModel: string;
+}


### PR DESCRIPTION
## Summary
- clean up unused eslint disable comments
- type `localSettings` with new interface
- wrap `persistLocalSettings` in `useCallback`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684263feead0833280d1017de7ff0d6e