### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ docker run -p 3000:3000 deepsite
 
 The repository includes a workflow to automatically build and publish the site
 using **GitHub Pages**. Push changes to the `main` branch and GitHub Actions
-will deploy the latest production build to the `gh-pages` environment.
+will deploy the latest production build to the `gh-pages` environment. The Vite
+configuration sets the base path to `/deepsite-locally/` when building for
+production so the site loads correctly from GitHub Pages.
 
 You can also build the static files locally:
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,11 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: "/deepsite/",
+  // Use the repository name as the base path so that assets load correctly on
+  // GitHub Pages. In development we serve from the root path, but when the
+  // site is deployed under `deepsite-locally` we need to prefix all asset URLs
+  // with the repo name.
+  base: process.env.NODE_ENV === "production" ? "/deepsite-locally/" : "/",
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: [{ find: "@", replacement: "/src" }],


### PR DESCRIPTION
## Summary
- set correct base path in vite config for GitHub Pages
- document the base path requirement in the README

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68481d0f7ee883328396589e9b5bd1ab