### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run -p 3000:3000 deepsite
 The repository includes a workflow to automatically build and publish the site
 using **GitHub Pages**. Push changes to the `main` branch and GitHub Actions
 will deploy the latest production build to the `gh-pages` environment. The Vite
-configuration sets the base path to `/deepsite-locally/` when building for
+configuration sets the base path to `/deepsite/` when building for
 production so the site loads correctly from GitHub Pages.
 
 You can also build the static files locally:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,9 +6,9 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineConfig({
   // Use the repository name as the base path so that assets load correctly on
   // GitHub Pages. In development we serve from the root path, but when the
-  // site is deployed under `deepsite-locally` we need to prefix all asset URLs
+  // site is deployed under `deepsite` we need to prefix all asset URLs
   // with the repo name.
-  base: process.env.NODE_ENV === "production" ? "/deepsite-locally/" : "/",
+  base: process.env.NODE_ENV === "production" ? "/deepsite/" : "/",
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: [{ find: "@", replacement: "/src" }],


### PR DESCRIPTION
## Summary
- adjust `base` in `vite.config.ts` to match repository name
- update README with the correct path for GitHub Pages

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68483d04301c833292ae2a70f952e862